### PR TITLE
Fix holiday check alias and adjust strategy defaults

### DIFF
--- a/weekend_test.py
+++ b/weekend_test.py
@@ -3,7 +3,7 @@
 Real Banking Test Script - Validates corrected loan calculator (Version 8.0+)
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from loan_calculator import RealBankingCalculator
 
 def test_transaction_date_logic():


### PR DESCRIPTION
## Summary
- fix docstring formatting in loan_calculator
- add `is_holidays` alias for backwards compatibility
- handle missing rate values when calculating strategies
- import `timedelta` for weekend tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8bc5870c8325aebfa1a1bb688de5